### PR TITLE
Exemplo com let estava com var. Exemplo não funcionava por esse motivo

### DIFF
--- a/aula_04_let_const/ex10_decl.js
+++ b/aula_04_let_const/ex10_decl.js
@@ -3,5 +3,7 @@ var semProblema = 2;
 console.log('semProblema =', semProblema);
 
 var comProblema = 1;
-var comProblema = 2;
+
+//dentro de um mesmo escopo não é possivel sobreescrever uma variavel com `let ou const`
+let comProblema = 2;
 console.log('comProblema =', comProblema);


### PR DESCRIPTION
Com **let** ou **Const** não é possivel sobreescrever dentro de um mesmo scopo uma variavel declarada anteriormente. o que sim é possivel fazer com var, pois javascript é uma linguagem no tipada.